### PR TITLE
metadata: Add 44 to supported Shell versions

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,6 +5,7 @@
   "settings-schema": "org.gnome.shell.extensions.replace-activities-label",
   "url": "https://github.com/Leleat/replace-activities-label",
   "shell-version": [
-    "43"
+    "43",
+    "44"
   ]
 }


### PR DESCRIPTION
It appears this is all that is needed to fix #1 (I changed it, rand the build script, and added the extension locally to my GNOME 44 install), but it's possible I'm missing something else.